### PR TITLE
Update webpipe.class.php

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://gumroad.com/l/hGYGh

--- a/webpipe.class.php
+++ b/webpipe.class.php
@@ -70,8 +70,8 @@ class WebPipe {
     
     // Set Method: If POST request, set it up + add data.
     if (strtolower($method) === 'post') {
-      curl_setopt($curl, CURLOPT_HEADER, 'application/json');
-      
+      curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+      
       // Convert data to Input Record
       if (sizeof($data)) {
         foreach ($data as $key => $val) {


### PR DESCRIPTION
typofix: CURLOPT_HEADER => CURLOPT_HTTPHEADER

the curl httpheader ended up with the default header (application/x-www-form-urlencoded) which breaks the webpipe spec
